### PR TITLE
Handle payment sign in import script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ import/
 Each record in `movimientos.json` follows the order:
 `Fecha, Cliente, Vendedor, Tipo de Movimiento, Documento, Importe, Comentario`.
 
+The converter also turns positive `Importe` values into negatives when the `Tipo de Movimiento` is `Pago` or `Devolución`, mirroring the Excel sheet's logic.
+
 Additional project documentation can be found in `README_CRM_Feraben_v2.md`.
 
 ## Contributing

--- a/import/convert.mjs
+++ b/import/convert.mjs
@@ -7,15 +7,23 @@ async function main() {
   const workbook = xlsx.readFile(input);
   const sheet = workbook.Sheets[workbook.SheetNames[0]];
   const rows = xlsx.utils.sheet_to_json(sheet, { defval: '' });
-  const formatted = rows.map(r => ({
-    fecha: r['Fecha'] || r['FECHA'] || r[Object.keys(r)[0]],
-    cliente: r['Cliente'] || r['CLIENTE'] || '',
-    vendedor: r['Vendedor'] || r['VENDEDOR'] || '',
-    tipo_movimiento: r['Tipo de Movimiento'] || r['TIPO DE MOVIMIENTO'] || '',
-    documento: r['Documento'] || r['DOCUMENTO'] || '',
-    importe: Number(r['Importe'] || r['IMPORTE'] || 0),
-    comentario: r['Comentario'] || r['COMENTARIO'] || ''
-  }));
+  const formatted = rows.map(r => {
+    const tipo = r['Tipo de Movimiento'] || r['TIPO DE MOVIMIENTO'] || '';
+    let importe = Number(r['Importe'] || r['IMPORTE'] || 0);
+    // Payments and refunds are stored as negatives even if the Excel shows them as positive
+    if ((tipo === 'Pago' || tipo === 'Devolución') && importe > 0) {
+      importe *= -1;
+    }
+    return {
+      fecha: r['Fecha'] || r['FECHA'] || r[Object.keys(r)[0]],
+      cliente: r['Cliente'] || r['CLIENTE'] || '',
+      vendedor: r['Vendedor'] || r['VENDEDOR'] || '',
+      tipo_movimiento: tipo,
+      documento: r['Documento'] || r['DOCUMENTO'] || '',
+      importe,
+      comentario: r['Comentario'] || r['COMENTARIO'] || ''
+    };
+  });
   await fs.writeFile(output, JSON.stringify(formatted, null, 2));
   console.log(`Saved ${formatted.length} records to ${output}`);
 }


### PR DESCRIPTION
## Summary
- adjust import conversion to flip positive "Pago" or "Devolución" to negative
- mention this conversion step in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765f7991b4832eaa2d154149ad5fcc