### PR TITLE
Implement Supabase API and export utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react-dom": "^18.2.0",
     "lucide-react": "^0.313.0",
     "xlsx": "^0.18.5",
-    "@supabase/supabase-js": "^2.0.0"
+    "@supabase/supabase-js": "^2.0.0",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,33 +1,69 @@
-// Placeholder API service
+import supabase from '../lib/supabase';
+
 export interface Cliente {
   id: number;
-  nombre: string;
+  razon_social: string;
+  nombre_fantasia?: string;
+  rut: string;
+  ciudad: string;
+  departamento: string;
+  vendedor_id: number;
+  vendedor_nombre?: string;
+  direccion?: string;
+  email?: string;
 }
 
 export interface Movimiento {
   id: number;
   cliente_id: number;
+  vendedor_id?: number;
+  fecha: string;
+  tipo_movimiento: string;
+  documento?: string;
   importe: number;
+  comentario?: string;
 }
 
 const apiService = {
   async getClientes(): Promise<Cliente[]> {
-    // TODO: replace with real API call
-    return [];
+    const { data, error } = await supabase
+      .from('clientes')
+      .select('*')
+      .order('razon_social');
+    if (error) throw error;
+    return (data as Cliente[]) || [];
   },
+
   async getMovimientos(): Promise<Movimiento[]> {
-    // TODO: replace with real API call
-    return [];
+    const { data, error } = await supabase
+      .from('movimientos')
+      .select('*')
+      .order('fecha');
+    if (error) throw error;
+    return (data as Movimiento[]) || [];
   },
-  async getEstadoCuenta(_clienteId: number): Promise<Movimiento[]> {
-    // TODO: replace with real API call
-    return [];
+
+  async getEstadoCuenta(clienteId: number): Promise<Movimiento[]> {
+    const { data, error } = await supabase
+      .from('movimientos')
+      .select('*')
+      .eq('cliente_id', clienteId)
+      .order('fecha');
+    if (error) throw error;
+    return (data as Movimiento[]) || [];
   },
+
   calcularSaldoCliente(movimientos: Movimiento[]): number {
     return movimientos.reduce((acc, m) => acc + m.importe, 0);
   },
+
   formatearMoneda(valor: number): string {
     return new Intl.NumberFormat('es-UY', { style: 'currency', currency: 'UYU' }).format(valor);
+  },
+
+  formatearFecha(fecha: string): string {
+    const d = new Date(fecha);
+    return d.toLocaleDateString('es-UY');
   },
 };
 

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -1,8 +1,65 @@
-// Placeholder export service
+import jsPDF from 'jspdf';
+import { utils, writeFile } from 'xlsx';
+import apiService, { Movimiento } from './api';
+
+type Filtro = 'completo' | 'ultimo_saldo_cero' | 'fechas';
+
+function filtrarMovimientos(
+  movimientos: Movimiento[],
+  filtro: Filtro,
+  desde?: string,
+  hasta?: string
+) {
+  if (filtro === 'ultimo_saldo_cero') {
+    let saldo = 0;
+    let index = -1;
+    movimientos.forEach((m, i) => {
+      saldo += m.importe;
+      if (saldo === 0) index = i;
+    });
+    return index >= 0 ? movimientos.slice(index + 1) : movimientos;
+  }
+
+  if (filtro === 'fechas') {
+    return movimientos.filter(m => {
+      const fecha = new Date(m.fecha).getTime();
+      if (desde && fecha < new Date(desde).getTime()) return false;
+      if (hasta && fecha > new Date(hasta).getTime()) return false;
+      return true;
+    });
+  }
+
+  return movimientos;
+}
+
 const exportService = {
-  async exportToExcel(_data: unknown): Promise<void> {
-    // TODO: implement real export logic
-    console.log('Exporting to Excel...', _data);
+  async exportarEstadoCuenta(
+    clienteId: number,
+    formato: 'pdf' | 'excel',
+    filtro: Filtro,
+    fechaDesde?: string,
+    fechaHasta?: string
+  ): Promise<void> {
+    const movimientos = await apiService.getEstadoCuenta(clienteId);
+    const filtrados = filtrarMovimientos(movimientos, filtro, fechaDesde, fechaHasta);
+
+    if (formato === 'excel') {
+      const worksheet = utils.json_to_sheet(filtrados);
+      const workbook = utils.book_new();
+      utils.book_append_sheet(workbook, worksheet, 'EstadoCuenta');
+      writeFile(workbook, 'estado_cuenta.xlsx');
+      return;
+    }
+
+    const doc = new jsPDF();
+    doc.text('Estado de Cuenta', 10, 10);
+    let y = 20;
+    filtrados.forEach(m => {
+      const line = `${apiService.formatearFecha(m.fecha)} - ${m.tipo_movimiento} - ${m.documento ?? ''} - ${apiService.formatearMoneda(m.importe)}`;
+      doc.text(line, 10, y);
+      y += 7;
+    });
+    doc.save('estado_cuenta.pdf');
   },
 };
 


### PR DESCRIPTION
## Summary
- fetch clients and movements from Supabase
- create export service for PDF/Excel generation
- enable PDF export via jsPDF dependency

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find packages)*
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876679562ac832ea64fd49e92c9c5d9