### PR TITLE
Add PWA service worker registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,9 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js');
-        });
-      }
+    <script type="module">
+      import { registerSW } from 'virtual:pwa-register';
+      registerSW();
     </script>
   </body>
 </html>

--- a/public/sw.ts
+++ b/public/sw.ts
@@ -1,0 +1,9 @@
+/// <reference lib="webworker" />
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', () => {
+  self.clients.claim();
+});


### PR DESCRIPTION
## Summary
- add a minimal service worker file
- register the service worker via `virtual:pwa-register`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768ce8390c832e8c5431c6ffce9baa